### PR TITLE
fix ls and cd commands

### DIFF
--- a/lib/cmd.rb
+++ b/lib/cmd.rb
@@ -59,12 +59,7 @@ class Cmd
   # Child: change job
   # Parent: report results
   def process_cmd(command, input_tokens)
-    cmd_pid = fork do
-      send command, input_tokens
-      exit
-    end
-
-    Process.waitpid(cmd_pid)
+    send command, input_tokens
   end
 
   def handle_unknown_cmd(command)

--- a/lib/commands/ls_command.rb
+++ b/lib/commands/ls_command.rb
@@ -24,7 +24,7 @@ class LsCommand
       return
     end
 
-    files.select! { |f| f.start_with?('.') } unless @opts.all?
+    files.select! { |f| !f.start_with?('.') } unless @opts.all?
 
     orig_dir = Dir.pwd
     Dir.chdir(@dir)

--- a/lib/shell_commands.rb
+++ b/lib/shell_commands.rb
@@ -5,6 +5,7 @@ require_relative 'commands/mkdir_command'
 require_relative 'commands/rm_command'
 require_relative 'commands/mv_command'
 require_relative 'commands/cp_command'
+require_relative 'commands/cd_command'
 require_relative 'commands/touch_command'
 require_relative 'commands/date_command'
 require_relative 'commands/cat_command'
@@ -36,49 +37,76 @@ module ShellCommands
     puts cmd_docs
   end
 
+  def exec_as_child
+    cmd_pid = fork do
+      yield
+      exit
+    end
+
+    Process.waitpid(cmd_pid)
+  end
+
   def do_clear(input_tokens)
     # ANSI sequence wont work with RubyMine console but will work with others (eg Ubuntu)
     puts "\e[H\e[2J"
   end
 
-  def do_cd(input_tokens); end
+  def do_cd(input_tokens)
+    CdCommand.new(input_tokens).execute
+  end
 
   def do_exit(input_tokens); end
 
   def do_ls(input_tokens)
-    LsCommand.new(input_tokens).execute
+    exec_as_child do
+      LsCommand.new(input_tokens).execute
+    end
   end
 
   def do_mv(input_tokens)
-    MvCommand.new(input_tokens).execute
+    exec_as_child do
+      MvCommand.new(input_tokens).execute
+    end
   end
 
   def do_cp(input_tokens)
-    CpCommand.new(input_tokens).execute
+    exec_as_child do
+      CpCommand.new(input_tokens).execute
+    end
   end
 
   def do_mkdir(input_tokens)
-    MkdirCommand.new(input_tokens).execute
+    exec_as_child do
+      MkdirCommand.new(input_tokens).execute
+    end
   end
 
   def do_rm(input_tokens)
-    RmCommand.new(input_tokens).execute
+    exec_as_child do
+      RmCommand.new(input_tokens).execute
+    end
   end
 
   def do_touch(input_tokens)
-    TouchCommand.new(input_tokens).execute
+    exec_as_child do
+      TouchCommand.new(input_tokens).execute
+    end
   end
 
   def do_echo(input_tokens); end
 
   # Concatenate file(s) to standard output
   def do_cat(input_tokens)
-    CatCommand.new(input_tokens).execute
+    exec_as_child do
+      CatCommand.new(input_tokens).execute
+    end
   end
 
   # Display the local date and time (e.g. Sat Nov 04 12:02:33 EST 1989)
   def do_date(input_tokens)
-    DateCommand.new(input_tokens).execute
+    exec_as_child do
+      DateCommand.new(input_tokens).execute
+    end
   end
 
   def docs(command_name)

--- a/test/file_command_test.rb
+++ b/test/file_command_test.rb
@@ -54,8 +54,8 @@ class FileCommandTest < Test::Unit::TestCase
 
   def test_ls
     files = Dir.entries(@sandbox_dir).sort!
-    no_hidden_files = files.select { |f| f.start_with?('.') }
-    sub_files = Dir.entries("#{@sandbox_dir}/subdir").select { |f| f.start_with?('.') }.sort!
+    no_hidden_files = files.select { |f| !f.start_with?('.') }
+    sub_files = Dir.entries("#{@sandbox_dir}/subdir").select { |f| !f.start_with?('.') }.sort!
 
     cmds = [
       'ls',
@@ -93,7 +93,11 @@ class FileCommandTest < Test::Unit::TestCase
                                  .map { |f| ColorText.rm_color(f) }
 
           assert_false(printed_files.empty?, "ls: No files printed for non-empty directory")
-          assert_equal(e_files, printed_files.sort, "ls: Incorrect files printed")
+          assert_equal(e_files, printed_files.sort, "ls: Incorrect files printed for \"#{cmd}\"")
+
+          unless tokens.include?('-a') or tokens.include?('--all')
+            assert_false(printed_files.any? { |f| f.start_with?('.') }, "Ls does not print hidden files by default")
+          end
         else
           # We have printed something to stderr
           assert_false($stderr.string.empty?, "ls: Invalid directory should print message to stderr")


### PR DESCRIPTION
Now we need to selectively fork for each shell_command because some, like cd need to be run in the parent process in order to work