### PR TITLE
Timer/ctimer implementation

### DIFF
--- a/lib/commands/delay_command.rb
+++ b/lib/commands/delay_command.rb
@@ -5,6 +5,7 @@ require_relative '../timer/ctimer'
 class DelayCommand
   include BaseCommand
 
+  NANOS_PER_SECOND = 1_000_000_000
   USAGE = <<~EOS.freeze
     Usage: delay [options] [time] "[message]"
       Prints [message] after a non-blocking delay of [time] nanoseconds.
@@ -30,7 +31,11 @@ class DelayCommand
     end
 
     child = Process.fork do
-      Ctimer::delay(@ns)
+      begin
+        Ctimer::delay(@ns / NANOS_PER_SECOND, @ns % NANOS_PER_SECOND)
+      rescue StandardError => e
+        puts "#{e.message}"
+      end
       puts @msg
       exit
     end

--- a/lib/timer/ctimer.c
+++ b/lib/timer/ctimer.c
@@ -1,8 +1,13 @@
 #include <stdio.h>
 #include <unistd.h>
+#include <time.h>
 #include "ctimer.h"
 
-void delay(int nanoseconds) {
-    // TODO: Replace sleep with nanosecond timer implementation
-    sleep(1);
+#define NS_PER_S 1000000000
+
+void delay(long long nanoseconds) {
+	struct timespec ts;
+	ts.tv_sec = nanoseconds / NS_PER_S;
+	ts.tv_nsec = nanoseconds % NS_PER_S;
+	nanosleep(&ts, NULL);
 }

--- a/lib/timer/ctimer.c
+++ b/lib/timer/ctimer.c
@@ -3,11 +3,9 @@
 #include <time.h>
 #include "ctimer.h"
 
-#define NS_PER_S 1000000000
-
-void delay(long long nanoseconds) {
+void delay(long seconds, long nanoseconds) {
 	struct timespec ts;
-	ts.tv_sec = nanoseconds / NS_PER_S;
-	ts.tv_nsec = nanoseconds % NS_PER_S;
+	ts.tv_sec = seconds;
+	ts.tv_nsec = nanoseconds;
 	nanosleep(&ts, NULL);
 }

--- a/lib/timer/ctimer.h
+++ b/lib/timer/ctimer.h
@@ -1,1 +1,1 @@
-void delay(long long nanoseconds);
+void delay(long seconds, long nanoseconds);

--- a/lib/timer/ctimer.h
+++ b/lib/timer/ctimer.h
@@ -1,1 +1,1 @@
-void delay(int nanoseconds);
+void delay(long long nanoseconds);

--- a/lib/timer/ctimer.i
+++ b/lib/timer/ctimer.i
@@ -3,4 +3,4 @@
 #include "ctimer.h"
 %}
 
-void delay(int nanoseconds);
+void delay(long long nanoseconds);

--- a/lib/timer/ctimer.i
+++ b/lib/timer/ctimer.i
@@ -3,4 +3,4 @@
 #include "ctimer.h"
 %}
 
-void delay(long long nanoseconds);
+void delay(long seconds, long nanoseconds);


### PR DESCRIPTION
Implemented high resolution timer using `nanosleep()`.

Added `seconds` parameter to delay method for easier casting between Ruby and C types with SWIG.

closes #50 